### PR TITLE
line items can be deleted

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -1,5 +1,5 @@
-
 """View module for handling requests about line items"""
+
 from django.http import HttpResponseServerError
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
@@ -9,14 +9,15 @@ from bangazonapi.models import OrderProduct, Order, Product, Customer
 
 
 class LineItemSerializer(serializers.HyperlinkedModelSerializer):
-    """JSON serializer for line items """
+    """JSON serializer for line items"""
+
     class Meta:
         model = OrderProduct
         url = serializers.HyperlinkedIdentityField(
-            view_name='lineitem',
-            lookup_field='id'
+            view_name='lineitem', lookup_field='id'
         )
         fields = ('id', 'url', 'order', 'product')
+
 
 class LineItems(ViewSet):
     """Line items for Bangazon orders"""
@@ -77,6 +78,7 @@ class LineItems(ViewSet):
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
+            order_product.delete()
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 
@@ -84,4 +86,6 @@ class LineItems(ViewSet):
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
 
         except Exception as ex:
-            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )


### PR DESCRIPTION
Deleting a lineitem from cart is now actually deleting the item.

## Changes

- Previously, no deletion was happening in the database, even though the server was responding with a 204 OK.
- Inside of lineitem.py, I added `order_product.delete()`. This was missing before, which made it so nothing was actually being deleted.

## Testing

Description of how to test code...

- [x] Ensure the client and server side repos are up to date with this branch.
- [x] Add item(s) to cart.
- [x] Remove previously added items. No errors should be popping up and the cart should re render upon each deletion.

