### PR TITLE
Added PaymentSerializer to order.py

### DIFF
--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -28,15 +28,35 @@ class OrderLineItemSerializer(serializers.HyperlinkedModelSerializer):
         depth = 1
 
 
+class PaymentSerializer(serializers.HyperlinkedModelSerializer):
+    """JSON serializer for payment types"""
+
+    class Meta:
+        model = Payment
+        url = serializers.HyperlinkedIdentityField(
+            view_name="payment", lookup_field="id"
+        )
+        fields = ("id", "merchant_name", "account_number", "expiration_date")
+
+
 class OrderSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for customer orders"""
 
     lineitems = OrderLineItemSerializer(many=True)
+    payment_type = PaymentSerializer(many=False)
 
     class Meta:
         model = Order
         url = serializers.HyperlinkedIdentityField(view_name="order", lookup_field="id")
-        fields = ("id", "url", "created_date", "payment_type", "customer", "lineitems")
+        fields = (
+            "id",
+            "url",
+            "created_date",
+            "payment_type",
+            "customer",
+            "lineitems",
+            "completed_date",
+        )
 
 
 class Orders(ViewSet):
@@ -139,6 +159,7 @@ class Orders(ViewSet):
                     "created_date": "2019-08-16",
                     "payment_type": "http://localhost:8000/paymenttypes/1",
                     "customer": "http://localhost:8000/customers/5"
+                    "completed_date": "2019-08-16"
                 }
             ]
         """


### PR DESCRIPTION
## Changes

1. Added a `PaymentSerializer` to `order.py`
2. Updated `OrderSerializer` to include the embedded `payment_type` field

## Requests / Responses

**Request**

In the `my-orders.js` client-side module the `getOrders()` fn will:
GET `/orders` lists the orders for the user

```js
export function getOrders() {
  return fetchWithResponse('orders', {
    headers: {
      Authorization: `Token ${localStorage.getItem('token')}`,
    },
  });
}
```

**Response**

```json
{
    "id": 11,
    "url": "http://localhost:8000/orders/11",
    "created_date": "2024-09-24",
    "payment_type": {
        "id": 1,
        "merchant_name": "Visa",
        "account_number": "24ijio68948fj8439",
        "expiration_date": "2020-01-01"
    },
    "customer": "http://localhost:8000/customers/4",
    "lineitems": [
        {
            "id": 10,
            "product": {
                "id": 2,
                "name": "Golf",
                "price": 653.59,
                "number_sold": 3,
                "description": "1994 Volkswagen",
                "quantity": 4,
                "created_date": "2019-07-10",
                "location": "Paris",
                "image_path": "http://localhost:8000/media/products/vehicle.png",
                "average_rating": 0
            }
        }
    ],
    "completed_date": "2024-09-24T15:05:49.864499Z"
}
```

## Testing

- [ ] Restart Debugger with new branch
- [ ] Ensure you have an authorized user logged in, and add at least 1 item to cart
- [ ] Complete the order by entering payment details
- [ ] After the 404 Screen appears, navigate to the `/my-orders` URL ending
- [ ] Verify that the purchase order details appear & are accurate (checking orders in network tab is helpful)


## Related Issues

- Fixes #85
- Fixes #22