### PR TITLE
Bug/all-payment-types

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -58,10 +58,12 @@ class Payments(ViewSet):
         try:
             payment_type = Payment.objects.get(pk=pk)
             serializer = PaymentSerializer(payment_type, context={"request": request})
+            payment_type = Payment.objects.get(pk=pk)             # Get the payment_type by its id
+            serializer = PaymentSerializer(
+                payment_type, context={'request': request})
             return Response(serializer.data)
         except Exception as ex:
             return HttpResponseServerError(ex)
-
     def destroy(self, request, pk=None):
         """Handle DELETE requests for a single payment type
 

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -86,7 +86,8 @@ class Payments(ViewSet):
 
     def list(self, request):
         """Handle GET requests to payment type resource"""
-        payment_types = Payment.objects.all()
+        current_user = Customer.objects.get(user=request.auth.user)
+        payment_types = Payment.objects.filter(customer=current_user)
 
         customer_id = self.request.query_params.get("customer", None)
 


### PR DESCRIPTION
**This pull request fixes an issue where all payment types were returned when a GET request was made to the `/paymenttypes` endpoint. Now, only the payment types associated with the authenticated user are returned.**

## Changes

- Updated the `list` method in the `Payments` view to filter payment types based on the authenticated user's customer profile.
- Enhanced the handling of user authentication to ensure the correct payment types are retrieved.

## Requests / Responses

**Request**

GET `/paymenttypes`

GET http://localhost:8000/paymenttypes
Authorization: Token <your_auth_token>

**Response**

HTTP/1.1 200 OK

```json
  {
    "id": 1,
    "url": "http://localhost:8000/paymenttypes/1",
    "merchant_name": "Visa",
    "account_number": "24ijio68948fj8439",
    "expiration_date": "2020-01-01",
    "create_date": "2019-11-11"
  }
```

## Testing
- [x] Submit a GET request to `/paymenttypes` with a valid authentication token.
- [x] Verify that only payment types associated with the authenticated user are returned.
- [x] Confirm that an empty array is returned if the user has no payment types.