### PR TITLE
Chore/complete-order-test

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -39,8 +39,9 @@ class Payments(ViewSet):
             Response -- JSON serialized payment instance
         """
         new_payment = Payment()
-        new_payment.merchant_name = request.data["merchant"]
-        new_payment.account_number = request.data["acctNumber"]
+        new_payment.merchant_name = request.data["merchant_name"]
+        new_payment.account_number = request.data["account_number"]
+        new_payment.expiration_date = request.data["expiration_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()
@@ -58,12 +59,12 @@ class Payments(ViewSet):
         try:
             payment_type = Payment.objects.get(pk=pk)
             serializer = PaymentSerializer(payment_type, context={"request": request})
-            payment_type = Payment.objects.get(pk=pk)             # Get the payment_type by its id
-            serializer = PaymentSerializer(
-                payment_type, context={'request': request})
+            payment_type = Payment.objects.get(pk=pk)  # Get the payment_type by its id
+            serializer = PaymentSerializer(payment_type, context={"request": request})
             return Response(serializer.data)
         except Exception as ex:
             return HttpResponseServerError(ex)
+
     def destroy(self, request, pk=None):
         """Handle DELETE requests for a single payment type
 

--- a/tests/order.py
+++ b/tests/order.py
@@ -1,7 +1,7 @@
 import json
 from rest_framework import status
 from rest_framework.test import APITestCase
-from datetime import datetime
+from django.utils import timezone
 
 
 class OrderTests(APITestCase):
@@ -101,6 +101,13 @@ class OrderTests(APITestCase):
         # Add product
         self.test_add_product_to_order()
 
+        # Get the order ID
+        url = "/orders"
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.get(url, None, format="json")
+        json_response = json.loads(response.content)
+        order_id = json_response[0]["id"]
+
         # Add payment type
         url = "/paymenttypes"
         data = {
@@ -116,13 +123,13 @@ class OrderTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # Complete order
-        url = "/orders"
-        completed_date = datetime.now().isoformat()
+        url = f"/orders/{order_id}/complete"
+        completed_date = timezone.now().isoformat()
         data = {"payment_type": 1, "completed_date": completed_date}
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
-        response = self.client.post(url, data, format="json")
+        response = self.client.put(url, data, format="json")
 
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         # Get order and verify it was completed
         url = "/orders/1"

--- a/tests/order.py
+++ b/tests/order.py
@@ -1,6 +1,7 @@
 import json
 from rest_framework import status
 from rest_framework.test import APITestCase
+from datetime import datetime
 
 
 class OrderTests(APITestCase):
@@ -9,9 +10,16 @@ class OrderTests(APITestCase):
         Create a new account and create sample category
         """
         url = "/register"
-        data = {"username": "steve", "password": "Admin8*", "email": "steve@stevebrownlee.com",
-                "address": "100 Infinity Way", "phone_number": "555-1212", "first_name": "Steve", "last_name": "Brownlee"}
-        response = self.client.post(url, data, format='json')
+        data = {
+            "username": "steve",
+            "password": "Admin8*",
+            "email": "steve@stevebrownlee.com",
+            "address": "100 Infinity Way",
+            "phone_number": "555-1212",
+            "first_name": "Steve",
+            "last_name": "Brownlee",
+        }
+        response = self.client.post(url, data, format="json")
         json_response = json.loads(response.content)
         self.token = json_response["token"]
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -19,16 +27,22 @@ class OrderTests(APITestCase):
         # Create a product category
         url = "/productcategories"
         data = {"name": "Sporting Goods"}
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.post(url, data, format='json')
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
 
         # Create a product
         url = "/products"
-        data = { "name": "Kite", "price": 14.99, "quantity": 60, "description": "It flies high", "category_id": 1, "location": "Pittsburgh" }
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.post(url, data, format='json')
+        data = {
+            "name": "Kite",
+            "price": 14.99,
+            "quantity": 60,
+            "description": "It flies high",
+            "category_id": 1,
+            "location": "Pittsburgh",
+        }
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
 
     def test_add_product_to_order(self):
         """
@@ -36,23 +50,22 @@ class OrderTests(APITestCase):
         """
         # Add product to order
         url = "/cart"
-        data = { "product_id": 1 }
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.post(url, data, format='json')
+        data = {"product_id": 1}
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         # Get cart and verify product was added
         url = "/cart"
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.get(url, None, format='json')
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.get(url, None, format="json")
         json_response = json.loads(response.content)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(json_response["id"], 1)
         self.assertEqual(json_response["size"], 1)
         self.assertEqual(len(json_response["lineitems"]), 1)
-
 
     def test_remove_product_from_order(self):
         """
@@ -63,22 +76,62 @@ class OrderTests(APITestCase):
 
         # Remove product from cart
         url = "/cart/1"
-        data = { "product_id": 1 }
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.delete(url, data, format='json')
+        data = {"product_id": 1}
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.delete(url, data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         # Get cart and verify product was removed
         url = "/cart"
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.get(url, None, format='json')
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.get(url, None, format="json")
         json_response = json.loads(response.content)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(json_response["size"], 0)
         self.assertEqual(len(json_response["lineitems"]), 0)
 
-    # TODO: Complete order by adding payment type
+    # TODO: Complete order by adding payment type & completed_date
+
+    def test_complete_order(self):
+        """
+        Ensure we can complete an order.
+        """
+        # Add product
+        self.test_add_product_to_order()
+
+        # Add payment type
+        url = "/paymenttypes"
+        data = {
+            "merchant_name": "Visa",
+            "account_number": "987654321",
+            "expiration_date": "2022-12-31",
+            "create_date": "2020-12-31",
+            "customer_id": 1,
+        }
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Complete order
+        url = "/orders"
+        completed_date = datetime.now().isoformat()
+        data = {"payment_type": 1, "completed_date": completed_date}
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Get order and verify it was completed
+        url = "/orders/1"
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.get(url, None, format="json")
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNotNone(json_response["completed_date"])
+        self.assertIsNotNone(json_response["payment_type"])
 
     # TODO: New line item is not added to closed order

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -10,13 +10,19 @@ class PaymentTests(APITestCase):
         Create a new account and create sample category
         """
         url = "/register"
-        data = {"username": "steve", "password": "Admin8*", "email": "steve@stevebrownlee.com",
-                "address": "100 Infinity Way", "phone_number": "555-1212", "first_name": "Steve", "last_name": "Brownlee"}
-        response = self.client.post(url, data, format='json')
+        data = {
+            "username": "steve",
+            "password": "Admin8*",
+            "email": "steve@stevebrownlee.com",
+            "address": "100 Infinity Way",
+            "phone_number": "555-1212",
+            "first_name": "Steve",
+            "last_name": "Brownlee",
+        }
+        response = self.client.post(url, data, format="json")
         json_response = json.loads(response.content)
         self.token = json_response["token"]
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
 
     def test_create_payment_type(self):
         """
@@ -28,10 +34,10 @@ class PaymentTests(APITestCase):
             "merchant_name": "American Express",
             "account_number": "111-1111-1111",
             "expiration_date": "2024-12-31",
-            "create_date": datetime.date.today()
+            "create_date": datetime.date.today(),
         }
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.post(url, data, format='json')
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
         json_response = json.loads(response.content)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)


### PR DESCRIPTION
Added an integration test to tests/order.py that tests adding a payment type to an order.

## Changes

- Item 1 - Created `test_complete_order`
- Item 2 - Updated `views/payment.py` to include `expiration_date` as well as updating the naming convention from `AcctNumber` to `account_number` & `merchant` to `merchant_name`. These were necessary to integrate with the tests.

## Testing

Description of how to test code...

- [x] Restart debugger on the new branch
- [x] Run test suite
```sh
python3 manage.py test tests -v 1
```
- [x] Ensure all tests pass

## Related Issues

- Fixes #85
- Fixes #22