### PR TITLE
Ft/delete-favorite-store

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -426,24 +426,24 @@ class Profile(ViewSet):
             @apiHeaderExample {String} Authorization
                 Token 9ba45f09651c5b0c404f37a2d2572c026c146611
 
-            @apiParam {Number} store_id ID of the favorite to remove
+            @apiParam {Number} favorite_id ID of the favorite to remove
 
             @apiSuccess (204) {Object} null No content, successful deletion
 
             @apiError (404) {Object} error Error message if favorite not found
-            @apiError (400) {Object} error Error message if store_id is missing
+            @apiError (400) {Object} error Error message if favorite_id is missing
             @apiError (403) {Object} error Error message if user doesn't have permission
             """
-            store_id = request.data.get("store_id")
+            favorite_id = request.data.get("favorite_id")
 
-            if not store_id:
+            if not favorite_id:
                 return Response(
-                    {"error": "store_id is required"},
+                    {"error": "favorite_id is required"},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
             try:
-                favorite = Favorite.objects.get(pk=store_id)
+                favorite = Favorite.objects.get(pk=favorite_id)
 
                 # Check if the authenticated user owns this favorite
                 if favorite.customer.user != request.auth.user:

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -292,7 +292,7 @@ class Profile(ViewSet):
 
         return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
-    @action(methods=["get", "post"], detail=False)
+    @action(methods=["get", "post", "delete"], detail=False)
     def favoritesellers(self, request):
 
         if request.method == "GET":
@@ -354,7 +354,7 @@ class Profile(ViewSet):
             )
             return Response(serializer.data)
 
-        if request.method == "POST":
+        elif request.method == "POST":
             """
             @api {POST} /profile/favoritesellers POST new favorite seller
             @apiName AddFavoriteSeller
@@ -415,6 +415,52 @@ class Profile(ViewSet):
                 return Response(serializer.data, status=status.HTTP_201_CREATED)
             else:
                 return Response(serializer.data, status=status.HTTP_200_OK)
+
+        elif request.method == "DELETE":
+            """
+            @api {DELETE} /profile/favoritesellers DELETE favorite seller
+            @apiName RemoveFavoriteSeller
+            @apiGroup UserProfile
+
+            @apiHeader {String} Authorization Auth token
+            @apiHeaderExample {String} Authorization
+                Token 9ba45f09651c5b0c404f37a2d2572c026c146611
+
+            @apiParam {Number} store_id ID of the favorite to remove
+
+            @apiSuccess (204) {Object} null No content, successful deletion
+
+            @apiError (404) {Object} error Error message if favorite not found
+            @apiError (400) {Object} error Error message if store_id is missing
+            @apiError (403) {Object} error Error message if user doesn't have permission
+            """
+            store_id = request.data.get("store_id")
+
+            if not store_id:
+                return Response(
+                    {"error": "store_id is required"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            try:
+                favorite = Favorite.objects.get(pk=store_id)
+
+                # Check if the authenticated user owns this favorite
+                if favorite.customer.user != request.auth.user:
+                    return Response(
+                        {"error": "You do not have permission to delete this favorite"},
+                        status=status.HTTP_403_FORBIDDEN,
+                    )
+
+                favorite.delete()
+                return Response(status=status.HTTP_204_NO_CONTENT)
+
+            except Favorite.DoesNotExist:
+                return Response(
+                    {"error": "Favorite not found"}, status=status.HTTP_404_NOT_FOUND
+                )
+
+        return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
 
 class LineItemSerializer(serializers.HyperlinkedModelSerializer):


### PR DESCRIPTION
Updated API to support deleting favorite stores. 

## Changes

- Item 1 - Created the `DELETE` method in the `favoritesellers` action in the `ProfileViewSet`

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

DELETE `/favoritesellers` Deletes a previously favorited store

 -- important Disclaimer: you'll need to first make a GET request to your favorites to check them. As this method works in the client, but relies on the specific favorite_id of the favorite, you'll need to make sure to find it to test in Postman. Testing this in the client is much easier --

```json
{
   "favorite_id": 7
}
```

**Response**

HTTP/1.1 204 No Content

```json

```

## Testing

- [ ] Restart Debugger on new branch
- [ ] Highly encourage to test this with the client code of favoriting and unfavoriting stores
- [ ] If you want to use Postman, simply use the request body like above for your `/favoritesellers` DELETE request and ensure you have an active `favorite_id` to test with


## Related Issues

- Fixes #85
- Fixes #22