### PR TITLE
Ft/create user store

### DIFF
--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -9,7 +9,7 @@ from bangazonapi.views import *
 # pylint: disable=invalid-name
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r"products", Products, "product")
-router.register(r"productcategories", ProductCategories, "productcategory")
+router.register(r"categories", ProductCategories, "productcategory")
 router.register(r"lineitems", LineItems, "orderproduct")
 router.register(r"customers", Customers, "customer")
 router.register(r"users", Users, "user")

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -298,8 +298,8 @@ class Products(ViewSet):
         if sold_only:
             products = products.annotate(
                 orders_count=Count(
-                    "orderproduct",
-                    filter=Q(orderproduct__order__payment_type__isnull=False),
+                    "lineitems",
+                    filter=Q(lineitems__order__payment_type__isnull=False),
                 )
             ).filter(orders_count__gt=0)
 

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -333,25 +333,6 @@ class Products(ViewSet):
 
         return Response(serializer.data)
 
-    @action(methods=["get"], detail=False)
-    def sold_count(self, request):
-        store_id = request.query_params.get("store_id", None)
-
-        if not store_id:
-            return Response(
-                {"error": "store_id is required"}, status=status.HTTP_400_BAD_REQUEST
-            )
-
-        sold_count = (
-            Product.objects.filter(
-                store__id=store_id, orderproduct__order__payment_type__isnull=False
-            )
-            .distinct()
-            .count()
-        )
-
-        return Response({"sold_count": sold_count})
-
     @action(methods=["post"], detail=True)
     def recommend(self, request, pk=None):
         """

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -14,6 +14,7 @@ from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.parsers import MultiPartParser, FormParser
 from .customer import CustomerSerializer
 from .store import StoreSerializer
+from django.db.models import Count, Q
 
 
 class ProductSerializer(serializers.ModelSerializer):
@@ -245,6 +246,13 @@ class Products(ViewSet):
         @apiName ListProducts
         @apiGroup Product
 
+        @apiParam {Number} store_id (Optional) Filter products by store ID
+        @apiParam {Number} category_id (Optional) Filter products by category ID
+        @apiParam {Number} min_price (Optional) Filter products by minimum price
+        @apiParam {Number} max_price (Optional) Filter products by maximum price
+        @apiParam {Number} quantity (Optional) Filter products by minimum quantity
+        @apiParam {Number} number_sold (Optional) Filter products by minimum number sold
+
         @apiSuccess (200) {Object[]} products Array of products
         @apiSuccessExample {json} Success
             [
@@ -262,29 +270,19 @@ class Products(ViewSet):
                     "category": {
                         "url": "http://localhost:8000/productcategories/6",
                         "name": "Games/Toys"
+                    },
+                    "store": {
+                        "id": 1,
+                        "name": "My Store"
                     }
                 },
-                {
-                    "id": 102,
-                    "name": "Basketball",
-                    "price": 29.99,
-                    "number_sold": 5,
-                    "description": "A great outdoor game",
-                    "quantity": 30,
-                    "created_date": "2019-10-23",
-                    "location": "Chicago",
-                    "image_path": null,
-                    "average_rating": 4.5,
-                    "category": {
-                        "url": "http://localhost:8000/productcategories/6",
-                        "name": "Games/Toys"
-                    }
-                }
+                # ... more products
             ]
         """
         products = Product.objects.all()
 
         # Filtering
+        store_id = request.query_params.get("store_id", None)
         category_id = request.query_params.get("category_id", None)
         min_price = request.query_params.get("min_price", None)
         max_price = request.query_params.get("max_price", None)
@@ -292,6 +290,18 @@ class Products(ViewSet):
         number_sold = request.query_params.get("number_sold", None)
         location = request.query_params.get("location", None)
         direction = request.query_params.get("direction", None)
+        sold_only = request.query_params.get("sold_only", "false").lower() == "true"
+
+        if store_id:
+            products = products.filter(store__id=store_id)
+
+        if sold_only:
+            products = products.annotate(
+                orders_count=Count(
+                    "orderproduct",
+                    filter=Q(orderproduct__order__payment_type__isnull=False),
+                )
+            ).filter(orders_count__gt=0)
 
         if category_id:
             products = products.filter(category_id=category_id)
@@ -322,6 +332,25 @@ class Products(ViewSet):
         )
 
         return Response(serializer.data)
+
+    @action(methods=["get"], detail=False)
+    def sold_count(self, request):
+        store_id = request.query_params.get("store_id", None)
+
+        if not store_id:
+            return Response(
+                {"error": "store_id is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        sold_count = (
+            Product.objects.filter(
+                store__id=store_id, orderproduct__order__payment_type__isnull=False
+            )
+            .distinct()
+            .count()
+        )
+
+        return Response({"sold_count": sold_count})
 
     @action(methods=["post"], detail=True)
     def recommend(self, request, pk=None):


### PR DESCRIPTION
Store owners can now receive more information about their products, specifically what is selling and what has sold. 

## Changes

1. Updated `Products` ViewSet to include further filtering in the `list` method for `sold_only` & `store_id`

## Requests / Responses

**Request**

GET `/products?store_id=3&sold_only=true` Will show products that have sold from that store

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 45,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 1,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "Toronto",
        "image_path": "http://localhost:8000/media/products/vehicle.png",
        "average_rating": 0,
        "store": {
            "id": 3,
            "name": "Gourmet Delights",
            "description": "Exclusive gourmet food items from around the world.",
            "seller": {
                "id": 5,
                "url": "http://localhost:8000/users/5",
                "username": "steve",
                "password": "pbkdf2_sha256$870000$RiTFiizLjJI61JJfl6OPJS$lRZ1avcZZ6YxhgLSRX/uuhffPuL7+RypUwGyVq+73Sg=",
                "first_name": "Steve",
                "last_name": "Brownlee",
                "email": "steve@stevebrownlee.com",
                "is_active": true,
                "date_joined": "2019-10-10T19:12:13.676000Z"
            },
            "items_for_sale": 53
        }
    }
]
```

## Testing

Description of how to test code...

- [ ] Restart debugger
- [ ] Either make a GET request in Postman with the example above or follow the test instructions from the client PR found [HERE](https://github.com/NSS-Day-Cohort-71/bangazon-client-404prime/pull/14).
- [ ] Verify that your responses show above or similar depending on the products/store/user that you have chosen to test with. This test was with the  **STEVE** user.


## Related Issues

- Fixes #85
- Fixes #22