### PR TITLE
adjusted the number_sold filtering on list in products

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -330,8 +330,14 @@ class Products(ViewSet):
         if quantity:
             products = products.filter(quantity__gte=quantity)
 
-        if number_sold:
-            products = products.filter(number_sold__gte=number_sold)
+        number_sold = int(request.query_params.get("number_sold", 0))
+        if number_sold is not None:
+            products = products.annotate(
+                sold_count=Count(
+                    "lineitems",
+                    filter=Q(lineitems__order__payment_type__isnull=False),
+                )
+            ).filter(sold_count__gte=number_sold)
 
         if location:
             products = products.filter(location__icontains=location)


### PR DESCRIPTION
This PR addresses an issue where filtering products by `number_sold` was causing a FieldError. The problem arose because `number_sold` is a property method, not a database field. To resolve this, we implemented a database-level solution using Django's annotation feature. We now annotate the product queryset with a `sold_count`, calculated by counting related `lineitems` associated with completed orders. This allows efficient filtering of products based on their sales numbers directly in the database query, improving performance and scalability, especially for large datasets.

## Changes

- Item 1 - Adjusted the filtering logic on `number_sold` in the `list` method of the Products ViewSet. 

```py
products = products.annotate(
    sold_count=Count(
        'lineitems',
        filter=Q(lineitems__order__payment_type__isnull=False)
    )
).filter(sold_count__gte=number_sold)
```


## Requests / Responses

**Request**

GET: 
http://localhost:8000/products?number_sold=1
http://localhost:8000/products?number_sold=2
http://localhost:8000/products?number_sold=20

**Response** (for sold = 1 example)

HTTP/1.1 200 OK

```json
[
    {
        "id": 45,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 1,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "Toronto",
        "image_path": "http://localhost:8000/media/products/vehicle.png",
        "average_rating": 0,
        "store": {
            "id": 1,
            "name": "Tech Emporium",
            "description": "Your one-stop shop for all things tech.",
            "seller": {
                "id": 7,
                "url": "http://localhost:8000/users/7",
                "username": "jisie",
                "password": "pbkdf2_sha256$150000$fHDURJBIASpx$trZS1MWc6YiNe5EYNBap+P+zMAwpNgNbUZH/b9bgvdw=",
                "first_name": "Jisie",
                "last_name": "David",
                "email": "jisie@jisiedavid.com",
                "is_active": true,
                "date_joined": "2019-10-10T22:48:19.899000Z"
            },
            "items_for_sale": 45
        },
        "is_liked": false
    },
    {
        "id": 50,
        "name": "Golf",
        "price": 653.59,
        "number_sold": 2,
        "description": "1994 Volkswagen",
        "quantity": 4,
        "created_date": "2019-07-10",
        "location": "Berlin",
        "image_path": "http://localhost:8000/media/products/vehicle.png",
        "average_rating": 3.25,
        "store": {
            "id": 1,
            "name": "Tech Emporium",
            "description": "Your one-stop shop for all things tech.",
            "seller": {
                "id": 7,
                "url": "http://localhost:8000/users/7",
                "username": "jisie",
                "password": "pbkdf2_sha256$150000$fHDURJBIASpx$trZS1MWc6YiNe5EYNBap+P+zMAwpNgNbUZH/b9bgvdw=",
                "first_name": "Jisie",
                "last_name": "David",
                "email": "jisie@jisiedavid.com",
                "is_active": true,
                "date_joined": "2019-10-10T22:48:19.899000Z"
            },
            "items_for_sale": 45
        },
        "is_liked": false
    }
]
```

## Testing

- [ ] Restart debugger
- [ ] Open Postman and make a few get requests with the examples above
- [ ] Either verify that the products listed have the corresponding "number_sold" to match the query or returns an empty array for when products have no reached that sold count


## Related Issues

- Fixes #85
- Fixes #22